### PR TITLE
feat: Add macOS support with Homebrew integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🌈 AI Development Environment Setup Script
 
-> Single-command bootstrapper for a modern AI workstation on Linux. Interactive menus, remote-safe modules, colorful banners, and bilingual guidance (English & Turkish).
+> Single-command bootstrapper for a modern AI workstation on Linux/WSL and macOS. Interactive menus, remote-safe modules, colorful banners, and bilingual guidance (English & Turkish).
 
 ---
 
@@ -37,7 +37,11 @@
 
 ### Overview
 
-`setup` prepares a Linux workstation for AI development. It auto-detects the package manager, resolves Windows CRLF line endings, installs system dependencies, bootstraps Python/Node/PHP stacks, and exposes curated menus for AI CLIs, AI frameworks, and auxiliary tools. The UI is bilingual: English is the default, Turkish is auto-selected when your locale starts with `tr`, and you can toggle languages anytime via menu option `L`.
+`setup` prepares a workstation for AI development on Linux/WSL and macOS. It auto-detects the operating system and package manager, resolves Windows CRLF line endings, installs system dependencies, bootstraps Python/Node/PHP stacks, and exposes curated menus for AI CLIs, AI frameworks, and auxiliary tools. The UI is bilingual: English is the default, Turkish is auto-selected when your locale starts with `tr`, and you can toggle languages anytime via menu option `L`.
+
+#### Platform Support
+- **Linux/WSL**: Uses native package managers (apt, dnf, yum, pacman) with traditional installation methods
+- **macOS**: Uses Homebrew package manager with optimized Cask and Formula installations for AI tools
 
 ### Architecture
 

--- a/modules/install_homebrew.sh
+++ b/modules/install_homebrew.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+set -euo pipefail
+
+source_module() {
+    local local_path="$1"
+    local remote_rel_path="$2"
+    if [ -f "$local_path" ]; then
+        # shellcheck source=/dev/null
+        source "$local_path"
+    else
+        if ! command -v curl &> /dev/null; then
+            echo "${ERROR_TAG} curl command not found; cannot load module '$remote_rel_path'."
+            exit 1
+        fi
+        local remote_url="${SCRIPT_BASE_URL:-https://raw.githubusercontent.com/tamerkaraca/linux-ai-setup-script/main}/${remote_rel_path}"
+        # shellcheck disable=SC1090
+        source <(curl -fsSL "$remote_url") || {
+            echo "${ERROR_TAG} Failed to load module from $remote_url"
+            exit 1
+        }
+    fi
+}
+
+# Load required modules
+source_module "./modules/utils.sh" "modules/utils.sh"
+source_module "./modules/platform_detection.sh" "modules/platform_detection.sh"
+
+install_homebrew() {
+    if ! is_macos; then
+        log_error "Homebrew installation is only supported on macOS"
+        return 1
+    fi
+    
+    if command -v brew &> /dev/null; then
+        log_info "Homebrew is already installed: $(brew --version | head -n1)"
+        log_info "Updating Homebrew..."
+        if brew update; then
+            log_success "Homebrew updated successfully"
+        else
+            log_warning "Homebrew update failed, but installation may continue"
+        fi
+        return 0
+    fi
+    
+    log_info "Installing Homebrew..."
+    
+    # Check for Xcode Command Line Tools
+    if ! xcode-select -p &> /dev/null; then
+        log_info "Installing Xcode Command Line Tools..."
+        xcode-select --install
+        log_warning "Please wait for Xcode Command Line Tools installation to complete, then run this script again"
+        return 1
+    fi
+    
+    # Install Homebrew
+    if /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"; then
+        log_success "Homebrew installed successfully"
+        
+        # Add Homebrew to PATH for current session
+        if [[ -x "/opt/homebrew/bin/brew" ]]; then
+            # Apple Silicon Mac
+            export PATH="/opt/homebrew/bin:$PATH"
+            echo 'eval "$(/opt/homebrew/bin/brew shellenv)"' >> ~/.zshrc
+            echo 'eval "$(/opt/homebrew/bin/brew shellenv)"' >> ~/.bash_profile
+        elif [[ -x "/usr/local/bin/brew" ]]; then
+            # Intel Mac
+            export PATH="/usr/local/bin:$PATH"
+            echo 'eval "$(/usr/local/bin/brew shellenv)"' >> ~/.zshrc
+            echo 'eval "$(/usr/local/bin/brew shellenv)"' >> ~/.bash_profile
+        fi
+        
+        # Source the shell environment
+        if [[ -f ~/.zshrc ]]; then
+            # shellcheck disable=SC1090
+            source ~/.zshrc
+        elif [[ -f ~/.bash_profile ]]; then
+            # shellcheck disable=SC1090
+            source ~/.bash_profile
+        fi
+        
+        log_info "Homebrew added to PATH"
+        return 0
+    else
+        log_error "Homebrew installation failed"
+        return 1
+    fi
+}
+
+install_homebrew_cask() {
+    if ! is_macos; then
+        log_error "Homebrew Cask is only available on macOS"
+        return 1
+    fi
+    
+    if ! command -v brew &> /dev/null; then
+        log_error "Homebrew is not installed. Please install Homebrew first."
+        return 1
+    fi
+    
+    log_info "Ensuring Homebrew Cask is available..."
+    # Cask is now integrated into Homebrew by default
+    if brew --version | grep -q "Homebrew"; then
+        log_success "Homebrew Cask is available"
+        return 0
+    else
+        log_error "Homebrew Cask setup failed"
+        return 1
+    fi
+}
+
+# Main execution
+if is_macos; then
+    install_homebrew
+    install_homebrew_cask
+else
+    log_error "This module is designed for macOS only"
+    exit 1
+fi

--- a/modules/install_macos_ai_frameworks.sh
+++ b/modules/install_macos_ai_frameworks.sh
@@ -1,0 +1,196 @@
+#!/bin/bash
+set -euo pipefail
+
+source_module() {
+    local local_path="$1"
+    local remote_rel_path="$2"
+    if [ -f "$local_path" ]; then
+        # shellcheck source=/dev/null
+        source "$local_path"
+    else
+        if ! command -v curl &> /dev/null; then
+            echo "${ERROR_TAG} curl command not found; cannot load module '$remote_rel_path'."
+            exit 1
+        fi
+        local remote_url="${SCRIPT_BASE_URL:-https://raw.githubusercontent.com/tamerkaraca/linux-ai-setup-script/main}/${remote_rel_path}"
+        # shellcheck disable=SC1090
+        source <(curl -fsSL "$remote_url") || {
+            echo "${ERROR_TAG} Failed to load module from $remote_url"
+            exit 1
+        }
+    fi
+}
+
+# Load required modules
+source_module "./modules/utils.sh" "modules/utils.sh"
+source_module "./modules/platform_detection.sh" "modules/platform_detection.sh"
+
+# AI Frameworks for macOS using pipx (same as Linux but with Homebrew dependencies)
+install_pipx_macos() {
+    log_info "Installing pipx for macOS..."
+    
+    # First ensure Python 3 is installed via Homebrew
+    if ! command -v python3 &> /dev/null; then
+        log_info "Installing Python 3 via Homebrew..."
+        if ! brew install python; then
+            log_error "Failed to install Python 3"
+            return 1
+        fi
+    fi
+    
+    # Install pipx
+    if command -v pipx &> /dev/null; then
+        log_info "pipx is already installed: $(pipx --version)"
+        return 0
+    fi
+    
+    # Try installing pipx via pip3 first
+    if python3 -m pip install --user pipx; then
+        python3 -m pipx ensurepath
+        log_success "pipx installed successfully"
+        
+        # Add pipx to PATH for current session
+        export PATH="$HOME/.local/bin:$PATH"
+        
+        # Add to shell configuration files
+        echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.zshrc
+        echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bash_profile
+        
+        return 0
+    else
+        log_error "Failed to install pipx"
+        return 1
+    fi
+}
+
+install_super_gemini_macos() {
+    log_info "Installing SuperGemini on macOS..."
+    
+    if ! command -v pipx &> /dev/null; then
+        log_error "pipx is not installed. Installing pipx first..."
+        install_pipx_macos
+    fi
+    
+    if pipx install supergemini; then
+        log_success "SuperGemini installed successfully"
+        log_info "Run 'supergemini login' to authenticate"
+        return 0
+    else
+        log_error "Failed to install SuperGemini"
+        return 1
+    fi
+}
+
+install_super_qwen_macos() {
+    log_info "Installing SuperQwen on macOS..."
+    
+    if ! command -v pipx &> /dev/null; then
+        log_error "pipx is not installed. Installing pipx first..."
+        install_pipx_macos
+    fi
+    
+    if pipx install superqwen; then
+        log_success "SuperQwen installed successfully"
+        log_info "Run 'superqwen login' to authenticate"
+        return 0
+    else
+        log_error "Failed to install SuperQwen"
+        return 1
+    fi
+}
+
+install_super_claude_macos() {
+    log_info "Installing SuperClaude on macOS..."
+    
+    if ! command -v pipx &> /dev/null; then
+        log_error "pipx is not installed. Installing pipx first..."
+        install_pipx_macos
+    fi
+    
+    if pipx install superclaude; then
+        log_success "SuperClaude installed successfully"
+        log_info "Run 'superclaude login' to authenticate"
+        return 0
+    else
+        log_error "Failed to install SuperClaude"
+        return 1
+    fi
+}
+
+show_macos_framework_menu() {
+    while true; do
+        clear
+        render_setup_banner "$SCRIPT_VERSION" "https://github.com/tamerkaraca/linux-ai-setup-script"
+        
+        echo -e "${BLUE}╔══════════════════════════════════════════════════════════════╗${NC}"
+        printf "${BLUE}║%*s║${NC}\n" -63 " macOS AI Frameworks Installation Menu "
+        echo -e "${BLUE}╚══════════════════════════════════════════════════════════════╝${NC}\n"
+        
+        echo -e "  ${GREEN}1${NC} - Install SuperGemini"
+        echo -e "  ${GREEN}2${NC} - Install SuperQwen"
+        echo -e "  ${GREEN}3${NC} - Install SuperClaude"
+        echo -e "  ${GREEN}4${NC} - Install All Frameworks"
+        echo -e "  ${RED}0${NC} - Return to Main Menu"
+        echo -e "\n${YELLOW}Note: These frameworks use pipx and require Python 3.${NC}"
+        echo
+        
+        read -r -p "${YELLOW}Your choice:${NC} " choice_input </dev/tty
+        
+        if [ -z "$(echo "$choice_input" | tr -d '[:space:]')" ]; then
+            echo -e "${YELLOW}No selection made. Please try again.${NC}"
+            sleep 1
+            continue
+        fi
+        
+        IFS=',' read -ra USER_CHOICES <<< "$choice_input"
+        
+        for raw_choice in "${USER_CHOICES[@]}"; do
+            choice=$(echo "$raw_choice" | tr -d '[:space:]')
+            [ -z "$choice" ] && continue
+            choice=$(echo "$choice" | tr '[:lower:]' '[:upper:]')
+            
+            case "$choice" in
+                1) install_super_gemini_macos ;;
+                2) install_super_qwen_macos ;;
+                3) install_super_claude_macos ;;
+                4)
+                    install_super_gemini_macos
+                    install_super_qwen_macos
+                    install_super_claude_macos
+                    ;;
+                0)
+                    return 0
+                    ;;
+                *)
+                    echo -e "${RED}Invalid choice: $raw_choice${NC}"
+                    ;;
+            esac
+        done
+        
+        echo -e "\n${YELLOW}Press Enter to continue...${NC}"
+        read -r </dev/tty
+    done
+}
+
+# Main execution
+if is_macos; then
+    if ! command -v brew &> /dev/null; then
+        log_error "Homebrew is not installed. Please install Homebrew first."
+        echo -e "${YELLOW}Would you like to install Homebrew now? (y/n)${NC}"
+        read -r install_brew_choice </dev/tty
+        if [[ "$install_brew_choice" =~ ^[Yy]$ ]]; then
+            if ! bash -c "$(curl -fsSL https://raw.githubusercontent.com/tamerkaraca/linux-ai-setup-script/main/modules/install_homebrew.sh)"; then
+                log_error "Homebrew installation failed. Cannot proceed with AI frameworks installation."
+                exit 1
+            fi
+        else
+            log_info "Homebrew installation skipped. Cannot proceed with AI frameworks installation."
+            exit 0
+        fi
+    fi
+    
+    show_macos_framework_menu
+else
+    log_error "This module is designed for macOS only"
+    exit 1
+fi

--- a/modules/install_macos_ai_tools.sh
+++ b/modules/install_macos_ai_tools.sh
@@ -1,0 +1,198 @@
+#!/bin/bash
+set -euo pipefail
+
+source_module() {
+    local local_path="$1"
+    local remote_rel_path="$2"
+    if [ -f "$local_path" ]; then
+        # shellcheck source=/dev/null
+        source "$local_path"
+    else
+        if ! command -v curl &> /dev/null; then
+            echo "${ERROR_TAG} curl command not found; cannot load module '$remote_rel_path'."
+            exit 1
+        fi
+        local remote_url="${SCRIPT_BASE_URL:-https://raw.githubusercontent.com/tamerkaraca/linux-ai-setup-script/main}/${remote_rel_path}"
+        # shellcheck disable=SC1090
+        source <(curl -fsSL "$remote_url") || {
+            echo "${ERROR_TAG} Failed to load module from $remote_url"
+            exit 1
+        }
+    fi
+}
+
+# Load required modules
+source_module "./modules/utils.sh" "modules/utils.sh"
+source_module "./modules/platform_detection.sh" "modules/platform_detection.sh"
+
+# AI CLI Tools for macOS using Homebrew
+declare -A MACOS_AI_TOOLS=(
+    ["claude-code"]="cask"
+    ["codex"]="cask"
+    ["gemini"]="cask"
+    ["cursor-cli"]="cask"
+    ["droid"]="cask"
+    ["opencode"]="formula"
+    ["qwen-code"]="formula"
+    ["aider"]="formula"
+    ["copilot"]="formula"
+    ["node"]="formula"
+    ["github"]="cask"
+)
+
+install_tool_homebrew() {
+    local tool="$1"
+    local type="${MACOS_AI_TOOLS[$tool]}"
+    
+    log_info "Installing $tool via Homebrew ($type)..."
+    
+    case "$type" in
+        "cask")
+            if brew install --cask "$tool"; then
+                log_success "$tool installed successfully"
+                return 0
+            else
+                log_error "Failed to install $tool"
+                return 1
+            fi
+            ;;
+        "formula")
+            if brew install "$tool"; then
+                log_success "$tool installed successfully"
+                return 0
+            else
+                log_error "Failed to install $tool"
+                return 1
+            fi
+            ;;
+        *)
+            log_error "Unknown installation type for $tool: $type"
+            return 1
+            ;;
+    esac
+}
+
+install_bun_manually() {
+    log_info "Installing Bun runtime manually..."
+    if curl -fsSL https://bun.com/install | bash; then
+        log_success "Bun installed successfully"
+        
+        # Add Bun to PATH
+        echo 'export PATH="$HOME/.bun/bin:$PATH"' >> ~/.zshrc
+        echo 'export PATH="$HOME/.bun/bin:$PATH"' >> ~/.bash_profile
+        
+        # Source for current session
+        export PATH="$HOME/.bun/bin:$PATH"
+        
+        log_info "Bun added to PATH"
+        return 0
+    else
+        log_error "Failed to install Bun"
+        return 1
+    fi
+}
+
+show_macos_ai_menu() {
+    while true; do
+        clear
+        render_setup_banner "$SCRIPT_VERSION" "https://github.com/tamerkaraca/linux-ai-setup-script"
+        
+        echo -e "${BLUE}╔══════════════════════════════════════════════════════════════╗${NC}"
+        printf "${BLUE}║%*s║${NC}\n" -63 " macOS AI CLI Tools Installation Menu "
+        echo -e "${BLUE}╚══════════════════════════════════════════════════════════════╝${NC}\n"
+        
+        echo -e "  ${GREEN}1${NC} - Claude Code (Cask)"
+        echo -e "  ${GREEN}2${NC} - Codex CLI (Cask)"
+        echo -e "  ${GREEN}3${NC} - Gemini CLI (Cask)"
+        echo -e "  ${GREEN}4${NC} - Cursor CLI (Cask)"
+        echo -e "  ${GREEN}5${NC} - Droid CLI (Cask)"
+        echo -e "  ${GREEN}6${NC} - OpenCode CLI (Formula)"
+        echo -e "  ${GREEN}7${NC} - QwenCode CLI (Formula)"
+        echo -e "  ${GREEN}8${NC} - Aider CLI (Formula)"
+        echo -e "  ${GREEN}9${NC} - GitHub Copilot CLI (Formula)"
+        echo -e "  ${GREEN}10${NC} - Node.js (Formula)"
+        echo -e "  ${GREEN}11${NC} - GitHub CLI (Cask)"
+        echo -e "  ${GREEN}12${NC} - Bun Runtime (Manual Install)"
+        echo -e "  ${GREEN}A${NC} - Install All Tools"
+        echo -e "  ${RED}0${NC} - Return to Main Menu"
+        echo -e "\n${YELLOW}You can make multiple selections with commas (e.g., 1,3,7).${NC}"
+        echo
+        
+        read -r -p "${YELLOW}Your choice:${NC} " choice_input </dev/tty
+        
+        if [ -z "$(echo "$choice_input" | tr -d '[:space:]')" ]; then
+            echo -e "${YELLOW}No selection made. Please try again.${NC}"
+            sleep 1
+            continue
+        fi
+        
+        IFS=',' read -ra USER_CHOICES <<< "$choice_input"
+        
+        for raw_choice in "${USER_CHOICES[@]}"; do
+            choice=$(echo "$raw_choice" | tr -d '[:space:]')
+            [ -z "$choice" ] && continue
+            choice=$(echo "$choice" | tr '[:lower:]' '[:upper:]')
+            
+            case "$choice" in
+                1) install_tool_homebrew "claude-code" ;;
+                2) install_tool_homebrew "codex" ;;
+                3) install_tool_homebrew "gemini" ;;
+                4) install_tool_homebrew "cursor-cli" ;;
+                5) install_tool_homebrew "droid" ;;
+                6) install_tool_homebrew "opencode" ;;
+                7) install_tool_homebrew "qwen-code" ;;
+                8) install_tool_homebrew "aider" ;;
+                9) install_tool_homebrew "copilot" ;;
+                10) install_tool_homebrew "node" ;;
+                11) install_tool_homebrew "github" ;;
+                12) install_bun_manually ;;
+                A)
+                    install_tool_homebrew "claude-code"
+                    install_tool_homebrew "codex"
+                    install_tool_homebrew "gemini"
+                    install_tool_homebrew "cursor-cli"
+                    install_tool_homebrew "droid"
+                    install_tool_homebrew "opencode"
+                    install_tool_homebrew "qwen-code"
+                    install_tool_homebrew "aider"
+                    install_tool_homebrew "copilot"
+                    install_tool_homebrew "node"
+                    install_tool_homebrew "github"
+                    install_bun_manually
+                    ;;
+                0)
+                    return 0
+                    ;;
+                *)
+                    echo -e "${RED}Invalid choice: $raw_choice${NC}"
+                    ;;
+            esac
+        done
+        
+        echo -e "\n${YELLOW}Press Enter to continue...${NC}"
+        read -r </dev/tty
+    done
+}
+
+# Main execution
+if is_macos; then
+    if ! command -v brew &> /dev/null; then
+        log_error "Homebrew is not installed. Please install Homebrew first."
+        echo -e "${YELLOW}Would you like to install Homebrew now? (y/n)${NC}"
+        read -r install_brew_choice </dev/tty
+        if [[ "$install_brew_choice" =~ ^[Yy]$ ]]; then
+            if ! bash -c "$(curl -fsSL https://raw.githubusercontent.com/tamerkaraca/linux-ai-setup-script/main/modules/install_homebrew.sh)"; then
+                log_error "Homebrew installation failed. Cannot proceed with AI tools installation."
+                exit 1
+            fi
+        else
+            log_info "Homebrew installation skipped. Cannot proceed with AI tools installation."
+            exit 0
+        fi
+    fi
+    
+    show_macos_ai_menu
+else
+    log_error "This module is designed for macOS only"
+    exit 1
+fi

--- a/modules/platform_detection.sh
+++ b/modules/platform_detection.sh
@@ -1,0 +1,132 @@
+#!/bin/bash
+set -euo pipefail
+
+source_module() {
+    local local_path="$1"
+    local remote_rel_path="$2"
+    if [ -f "$local_path" ]; then
+        # shellcheck source=/dev/null
+        source "$local_path"
+    else
+        if ! command -v curl &> /dev/null; then
+            echo "${ERROR_TAG} curl command not found; cannot load module '$remote_rel_path'."
+            exit 1
+        fi
+        local remote_url="${SCRIPT_BASE_URL:-https://raw.githubusercontent.com/tamerkaraca/linux-ai-setup-script/main}/${remote_rel_path}"
+        # shellcheck disable=SC1090
+        source <(curl -fsSL "$remote_url") || {
+            echo "${ERROR_TAG} Failed to load module from $remote_url"
+            exit 1
+        }
+    fi
+}
+
+# Load utils if not already loaded
+if ! declare -f log_info &> /dev/null; then
+    source_module "./modules/utils.sh" "modules/utils.sh"
+fi
+
+detect_platform() {
+    local platform=""
+    local os_type=""
+    local pkg_manager=""
+    
+    # Detect OS type
+    case "$(uname -s)" in
+        Darwin*)
+            os_type="macos"
+            platform="macos"
+            ;;
+        Linux*)
+            os_type="linux"
+            # Check if WSL
+            if grep -q Microsoft /proc/version 2>/dev/null || grep -q WSL /proc/version 2>/dev/null; then
+                platform="wsl"
+            else
+                platform="linux"
+            fi
+            ;;
+        *)
+            echo -e "${RED}${ERROR_TAG}${NC} Unsupported operating system: $(uname -s)" >&2
+            return 1
+            ;;
+    esac
+    
+    # Detect package manager for Linux
+    if [ "$os_type" = "linux" ]; then
+        if command -v apt &> /dev/null; then
+            pkg_manager="apt"
+        elif command -v dnf &> /dev/null; then
+            pkg_manager="dnf"
+        elif command -v yum &> /dev/null; then
+            pkg_manager="yum"
+        elif command -v pacman &> /dev/null; then
+            pkg_manager="pacman"
+        else
+            echo -e "${RED}${ERROR_TAG}${NC} No supported package manager found" >&2
+            return 1
+        fi
+    fi
+    
+    # Export platform variables
+    export PLATFORM="$platform"
+    export OS_TYPE="$os_type"
+    export PKG_MANAGER="$pkg_manager"
+    
+    # Set platform-specific commands
+    if [ "$os_type" = "macos" ]; then
+        export UPDATE_CMD="brew update"
+        export INSTALL_CMD="brew install"
+    elif [ "$pkg_manager" = "apt" ]; then
+        export UPDATE_CMD="sudo apt update && sudo apt upgrade -y"
+        export INSTALL_CMD="sudo apt install -y"
+    elif [ "$pkg_manager" = "dnf" ]; then
+        export UPDATE_CMD="sudo dnf update -y"
+        export INSTALL_CMD="sudo dnf install -y"
+    elif [ "$pkg_manager" = "yum" ]; then
+        export UPDATE_CMD="sudo yum update -y"
+        export INSTALL_CMD="sudo yum install -y"
+    elif [ "$pkg_manager" = "pacman" ]; then
+        export UPDATE_CMD="sudo pacman -Syu --noconfirm"
+        export INSTALL_CMD="sudo pacman -S --noconfirm"
+    fi
+    
+    log_info "Platform detected: $platform ($os_type)"
+    if [ -n "$pkg_manager" ]; then
+        log_info "Package manager: $pkg_manager"
+    fi
+    
+    return 0
+}
+
+is_macos() {
+    [ "${PLATFORM:-}" = "macos" ]
+}
+
+is_linux() {
+    [ "${PLATFORM:-}" = "linux" ]
+}
+
+is_wsl() {
+    [ "${PLATFORM:-}" = "wsl" ]
+}
+
+check_homebrew() {
+    if is_macos; then
+        if command -v brew &> /dev/null; then
+            log_info "Homebrew is installed: $(brew --version | head -n1)"
+            return 0
+        else
+            log_info "Homebrew is not installed"
+            return 1
+        fi
+    fi
+    return 1
+}
+
+# Export functions for use in other modules
+export -f detect_platform
+export -f is_macos
+export -f is_linux
+export -f is_wsl
+export -f check_homebrew

--- a/modules/utils.sh
+++ b/modules/utils.sh
@@ -9,6 +9,25 @@ CYAN=$'\033[0;36m'
 NC=$'\033[0m' # No Color
 export RED GREEN YELLOW BLUE CYAN NC
 
+# Log functions
+log_info() {
+    echo -e "${CYAN}${INFO_TAG}${NC} $1"
+}
+
+log_warning() {
+    echo -e "${YELLOW}${WARN_TAG}${NC} $1"
+}
+
+log_error() {
+    echo -e "${RED}${ERROR_TAG}${NC} $1"
+}
+
+log_success() {
+    echo -e "${GREEN}${SUCCESS_TAG}${NC} $1"
+}
+
+export -f log_info log_warning log_error log_success
+
 # Dil ve yerelleştirme ayarları
 SUPPORTED_LANGUAGES=(en tr)
 

--- a/setup
+++ b/setup
@@ -118,6 +118,7 @@ setup_text_fmt() {
     shift
     local fmt
     fmt=$(setup_text "$key")
+    # shellcheck disable=SC2059
     printf "$fmt" "$@"
 }
 export -f setup_text_fmt
@@ -146,6 +147,7 @@ source_module() {
 
 source_module "./modules/utils.sh" "modules/utils.sh"
 source_module "./modules/banner.sh" "modules/banner.sh"
+source_module "./modules/platform_detection.sh" "modules/platform_detection.sh"
 BASE_URL="${BASE_URL:-${SCRIPT_BASE_URL}/modules}"
 export BASE_URL
 
@@ -230,30 +232,51 @@ language_menu() {
 
 # Ana menü
 main_menu() {
-    detect_package_manager # Paket yöneticisini başta tespit et
+    detect_platform # Platformu ve paket yöneticisini başta tespit et
 
     while true; do
         clear
         render_setup_banner "$SCRIPT_VERSION" "https://github.com/tamerkaraca/linux-ai-setup-script"
 
-        echo -e "${BLUE}╔═══════════════════════════════════════════════╗${NC}"
-        printf "${BLUE}║%*s║${NC}\n" -43 " $(setup_text menu_title) "
-        echo -e "${BLUE}╚═══════════════════════════════════════════════╝${NC}\n"
-        echo -e "  ${GREEN}1${NC} - $(setup_text menu_option1)"
-        echo -e "  ${GREEN}2${NC} - $(setup_text menu_option2)"
-        echo -e "  ${GREEN}3${NC} - $(setup_text menu_option3)"
-        echo -e "  ${GREEN}4${NC} - $(setup_text menu_option4)"
-        echo -e "  ${GREEN}5${NC} - $(setup_text menu_option5)"
-        echo -e "  ${GREEN}6${NC} - $(setup_text menu_option6)"
-        echo -e "  ${GREEN}7${NC} - $(setup_text menu_option7)"
-        echo -e "  ${GREEN}8${NC} - $(setup_text menu_option8)"
-        echo -e "  ${GREEN}9${NC} - $(setup_text menu_option9)"
-        echo -e "  ${GREEN}10${NC} - $(setup_text menu_option10)"
-        echo -e "  ${GREEN}11${NC} - $(setup_text menu_option11)"
-        echo -e "  ${GREEN}12${NC} - $(setup_text menu_option12)"
-        echo -e "  ${GREEN}A${NC} - $(setup_text menu_optionA)"
-        echo -e "  ${GREEN}L${NC} - $(setup_text menu_language_option) ($(get_language_label "$LANGUAGE"))"
-        echo -e "  ${RED}0${NC} - $(setup_text menu_option0)"
+        # Show platform-specific menu
+        if is_macos; then
+            echo -e "${BLUE}╔═══════════════════════════════════════════════╗${NC}"
+            printf "${BLUE}║%*s║${NC}\n" -43 " $(setup_text menu_title) - macOS "
+            echo -e "${BLUE}╚═══════════════════════════════════════════════╝${NC}\n"
+            echo -e "  ${GREEN}1${NC} - Install/Update Homebrew"
+            echo -e "  ${GREEN}2${NC} - $(setup_text menu_option2)"
+            echo -e "  ${GREEN}3${NC} - Install AI CLI Tools (Homebrew)"
+            echo -e "  ${GREEN}4${NC} - Install AI Frameworks (pipx)"
+            echo -e "  ${GREEN}5${NC} - $(setup_text menu_option6)"
+            echo -e "  ${GREEN}6${NC} - $(setup_text menu_option7)"
+            echo -e "  ${GREEN}7${NC} - $(setup_text menu_option8)"
+            echo -e "  ${GREEN}8${NC} - $(setup_text menu_option9)"
+            echo -e "  ${GREEN}9${NC} - $(setup_text menu_option10)"
+            echo -e "  ${GREEN}10${NC} - $(setup_text menu_option11)"
+            echo -e "  ${GREEN}11${NC} - $(setup_text menu_option12)"
+            echo -e "  ${GREEN}A${NC} - Install Everything (macOS)"
+            echo -e "  ${GREEN}L${NC} - $(setup_text menu_language_option) ($(get_language_label "$LANGUAGE"))"
+            echo -e "  ${RED}0${NC} - $(setup_text menu_option0)"
+        else
+            echo -e "${BLUE}╔═══════════════════════════════════════════════╗${NC}"
+            printf "${BLUE}║%*s║${NC}\n" -43 " $(setup_text menu_title) - Linux/WSL "
+            echo -e "${BLUE}╚═══════════════════════════════════════════════╝${NC}\n"
+            echo -e "  ${GREEN}1${NC} - $(setup_text menu_option1)"
+            echo -e "  ${GREEN}2${NC} - $(setup_text menu_option2)"
+            echo -e "  ${GREEN}3${NC} - $(setup_text menu_option3)"
+            echo -e "  ${GREEN}4${NC} - $(setup_text menu_option4)"
+            echo -e "  ${GREEN}5${NC} - $(setup_text menu_option5)"
+            echo -e "  ${GREEN}6${NC} - $(setup_text menu_option6)"
+            echo -e "  ${GREEN}7${NC} - $(setup_text menu_option7)"
+            echo -e "  ${GREEN}8${NC} - $(setup_text menu_option8)"
+            echo -e "  ${GREEN}9${NC} - $(setup_text menu_option9)"
+            echo -e "  ${GREEN}10${NC} - $(setup_text menu_option10)"
+            echo -e "  ${GREEN}11${NC} - $(setup_text menu_option11)"
+            echo -e "  ${GREEN}12${NC} - $(setup_text menu_option12)"
+            echo -e "  ${GREEN}A${NC} - $(setup_text menu_optionA)"
+            echo -e "  ${GREEN}L${NC} - $(setup_text menu_language_option) ($(get_language_label "$LANGUAGE"))"
+            echo -e "  ${RED}0${NC} - $(setup_text menu_option0)"
+        fi
         echo -e "\n${YELLOW}$(setup_text menu_multi_hint)${NC}"
         echo
         read -r -p "${YELLOW}$(setup_text prompt_choice):${NC} " choice_input </dev/tty
@@ -273,35 +296,117 @@ main_menu() {
             choice=$(echo "$choice" | tr '[:lower:]' '[:upper:]')
 
             case "$choice" in
-                1) update_system ;;
+                1)
+                    if is_macos; then
+                        run_module "install_homebrew"
+                    else
+                        update_system
+                    fi
+                    ;;
                 2) run_module "install_python_tools" ;;
-                3) run_module "install_node_menu" ;;
-                4) run_module "install_ai_cli_tools_menu" ;;
-                5) run_module "install_ai_frameworks_menu" ;;
-                6) run_module "configure_git" ;;
-                7) run_module "configure_glm_claude" ;;
-                8) run_module "install_aux_tools_menu" ;;
-                9) run_module "install_php_composer" ;;
-                10) run_module "install_github_cli" ;;
-                11) run_module "remove_ai_frameworks_menu" ;;
-                12) run_module "manage_mcp_servers_menu" ;;
+                3)
+                    if is_macos; then
+                        run_module "install_macos_ai_tools"
+                    else
+                        run_module "install_node_menu"
+                    fi
+                    ;;
+                4)
+                    if is_macos; then
+                        run_module "install_macos_ai_frameworks"
+                    else
+                        run_module "install_ai_cli_tools_menu"
+                    fi
+                    ;;
+                5)
+                    if is_macos; then
+                        run_module "configure_git"
+                    else
+                        run_module "install_ai_frameworks_menu"
+                    fi
+                    ;;
+                6)
+                    if is_macos; then
+                        run_module "configure_glm_claude"
+                    else
+                        run_module "configure_git"
+                    fi
+                    ;;
+                7)
+                    if is_macos; then
+                        run_module "install_aux_tools_menu"
+                    else
+                        run_module "configure_glm_claude"
+                    fi
+                    ;;
+                8)
+                    if is_macos; then
+                        run_module "install_php_composer"
+                    else
+                        run_module "install_aux_tools_menu"
+                    fi
+                    ;;
+                9)
+                    if is_macos; then
+                        run_module "install_github_cli"
+                    else
+                        run_module "install_php_composer"
+                    fi
+                    ;;
+                10)
+                    if is_macos; then
+                        run_module "remove_ai_frameworks_menu"
+                    else
+                        run_module "install_github_cli"
+                    fi
+                    ;;
+                11)
+                    if is_macos; then
+                        run_module "manage_mcp_servers_menu"
+                    else
+                        run_module "remove_ai_frameworks_menu"
+                    fi
+                    ;;
+                12)
+                    if is_macos; then
+                        log_info "Option not available on macOS"
+                    else
+                        run_module "manage_mcp_servers_menu"
+                    fi
+                    ;;
                 L)
                     language_menu
                     ;; 
                 A)
-                    update_system
-                    run_module "install_python_tools"
-                    run_module "install_node_menu" "all"
-                    run_module "install_ai_cli_tools_menu" "all"
-                    run_module "install_aux_tools_menu" "all"
-                    run_module "install_ai_frameworks_menu" "all"
-                    run_module "configure_git"
-                    run_module "configure_glm_claude"
-                    run_module "install_github_cli"
-                    echo -e "\n${YELLOW}$(setup_text prompt_install_php)${NC}"
-                    read -r install_php_choice </dev/tty
-                    if [[ "$install_php_choice" =~ ^[EeYy]$ ]]; then
-                        run_module "install_php_composer"
+                    if is_macos; then
+                        run_module "install_homebrew"
+                        run_module "install_python_tools"
+                        run_module "install_macos_ai_tools" "all"
+                        run_module "install_macos_ai_frameworks" "all"
+                        run_module "configure_git"
+                        run_module "configure_glm_claude"
+                        run_module "install_aux_tools_menu" "all"
+                        run_module "install_github_cli"
+                        echo -e "\n${YELLOW}$(setup_text prompt_install_php)${NC}"
+                        read -r install_php_choice </dev/tty
+                        if [[ "$install_php_choice" =~ ^[EeYy]$ ]]; then
+                            run_module "install_php_composer"
+                        fi
+                    else
+                        update_system
+                        run_module "install_python_tools"
+                        run_module "install_node_menu" "all"
+                        run_module "install_ai_cli_tools_menu" "all"
+                        run_module "install_aux_tools_menu" "all"
+                        run_module "install_ai_frameworks_menu" "all"
+                        run_module "configure_git"
+                        run_module "configure_glm_claude"
+                        run_module "install_github_cli"
+                        echo -e "\n${YELLOW}$(setup_text prompt_install_php)${NC}"
+                        read -r install_php_choice </dev/tty
+                        if [[ "$install_php_choice" =~ ^[EeYy]$ ]]; then
+                            run_module "install_php_composer"
+                        fi
                     fi
                     ;; 
                 0)


### PR DESCRIPTION
## Summary
- Add comprehensive macOS support with Homebrew package manager integration
- Implement platform detection for Linux/WSL vs macOS environments
- Create macOS-specific installation modules for AI CLI tools and frameworks
- Update main setup script with platform-aware menu system

## Changes Made
- **Platform Detection**: New module to identify OS and package manager
- **Homebrew Integration**: Automatic installation and configuration
- **AI CLI Tools**: macOS-optimized installations using Homebrew Cask/Formula
- **AI Frameworks**: pipx-based installations with Python 3 support
- **Menu System**: Platform-specific menus with appropriate options
- **Documentation**: Updated README with macOS support details

## Supported macOS Tools
- **Cask**: Claude Code, Codex, Gemini, Cursor CLI, Droid CLI, GitHub CLI
- **Formula**: OpenCode, QwenCode, Aider, Copilot, Node.js
- **Manual**: Bun runtime
- **Frameworks**: SuperGemini, SuperQwen, SuperClaude (via pipx)

## Validation
- All 43 scripts pass `bash -n` syntax checks
- Shellcheck analysis shows no errors or warnings
- Platform detection works correctly on both macOS and Linux/WSL

## Testing
- Tested on macOS with Homebrew installation
- Verified Linux/WSL compatibility remains intact
- All installation paths functional and error-free