### PR TITLE
feat: Add Jules CLI and Terminal Tools (Zsh, Oh My Zsh)

### DIFF
--- a/modules/install_ai_cli_tools_menu.sh
+++ b/modules/install_ai_cli_tools_menu.sh
@@ -27,6 +27,7 @@ declare -A AI_CLI_MENU_TEXT_EN=(
     ["ai_option11"]="Kilocode CLI"
     ["ai_option12"]="Auggie CLI"
     ["ai_option13"]="Droid CLI"
+    ["ai_option14"]="Jules CLI (Google)"
     ["ai_optionA"]="Install All AI CLI Tools"
     ["ai_option_return"]="Return to Main Menu"
     ["ai_menu_hint"]="You can make multiple selections with commas (e.g., 1,2,5)."
@@ -54,6 +55,7 @@ declare -A AI_CLI_MENU_TEXT_TR=(
     ["ai_option11"]="Kilocode CLI"
     ["ai_option12"]="Auggie CLI"
     ["ai_option13"]="Droid CLI"
+    ["ai_option14"]="Jules CLI (Google)"
     ["ai_optionA"]="Tüm AI CLI Araçlarını Kur"
     ["ai_option_return"]="Ana Menüye Dön"
     ["ai_menu_hint"]="Birden fazla seçim için virgül kullanabilirsiniz (örn: 1,2,5)."
@@ -193,6 +195,13 @@ install_ai_cli_tools_menu() {
                     success=1
                 fi
                 ;;
+            14)
+                label="Jules CLI"
+                login_hint="jules login"
+                if ! run_module "install_jules_cli" "$interactive"; then
+                    success=1
+                fi
+                ;;
             *)
                 echo -e "${RED}$(ai_cli_menu_text warning_invalid_choice): $option${NC}"
                 success=1
@@ -228,6 +237,7 @@ esac
             echo -e "  ${GREEN}11${NC} $(ai_cli_menu_text ai_option11)"
             echo -e "  ${GREEN}12${NC} $(ai_cli_menu_text ai_option12)"
             echo -e "  ${GREEN}13${NC} $(ai_cli_menu_text ai_option13)"
+            echo -e "  ${GREEN}14${NC} $(ai_cli_menu_text ai_option14)"
             echo -e "  ${GREEN}A${NC} $(ai_cli_menu_text ai_optionA)"
             echo -e "  ${RED}0${NC} $(ai_cli_menu_text ai_option_return)"
             echo -e "\n${YELLOW}$(ai_cli_menu_text ai_menu_hint)${NC}"
@@ -268,12 +278,12 @@ esac
             fi
 
             case $choice in
-                1|2|3|4|5|6|7|8|9|10|11|12|13)
+                1|2|3|4|5|6|7|8|9|10|11|12|13|14)
                     run_cli_choice "$choice" "$interactive_flag" || true
                     ;;
                 A)
                     batch_context=true
-                    for sub_choice in {1..13}; do
+                    for sub_choice in {1..14}; do
                         run_cli_choice "$sub_choice" "false" || true
                     done
                     all_installed=true
@@ -333,6 +343,7 @@ esac
                                 summary_hint="droid (Factory quickstart'a göre)"
                             fi
                             ;;
+                        "jules login") summary_hint="jules login" ;;
                     esac
                     echo -e "  ${GREEN}•${NC} ${summary_label}: ${GREEN}${summary_hint}${NC}"
                 else

--- a/modules/install_jules_cli.sh
+++ b/modules/install_jules_cli.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+set -euo pipefail
+
+UTILS_PATH="./modules/utils.sh"
+if [ ! -f "$UTILS_PATH" ] && [ -n "${BASH_SOURCE[0]:-}" ]; then
+    UTILS_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/utils.sh"
+fi
+# shellcheck source=/dev/null
+[ -f "$UTILS_PATH" ] && source "$UTILS_PATH"
+: "${NPM_LAST_INSTALL_PREFIX:=}"
+
+: "${RED:=$'\033[0;31m'}"
+: "${GREEN:=$'\033[0;32m'}"
+: "${YELLOW:=$'\033[1;33m'}"
+: "${BLUE:=$'\033[0;34m'}"
+: "${CYAN:=$'\033[0;36m'}"
+: "${NC:=$'\033[0m'}"
+
+declare -A JULES_TEXT_EN=(
+    ["install_title"]="Starting Jules CLI installation..."
+    ["npm_missing"]="The npm command was not found. Please install Node.js first."
+    ["install_fail"]="Jules CLI npm installation failed."
+    ["prefix_notice"]="Install prefix: %s"
+    ["version_info"]="Jules CLI version: %s"
+    ["interactive_intro"]="You need to sign in to Jules CLI now."
+    ["interactive_command"]="Please run 'jules login' and complete the flow."
+    ["interactive_wait"]="Press Enter once authentication is complete."
+    ["manual_skip"]="Authentication skipped in 'Install All' mode."
+    ["manual_reminder"]="Please run '${GREEN}jules login${NC}' manually later."
+    ["manual_hint"]="Manual authentication may be required."
+    ["install_done"]="Jules CLI installation completed!"
+    ["auth_prompt"]="Press Enter to continue..."
+)
+
+declare -A JULES_TEXT_TR=(
+    ["install_title"]="Jules CLI kurulumu başlatılıyor..."
+    ["npm_missing"]="npm komutu bulunamadı. Lütfen önce Node.js kurun."
+    ["install_fail"]="Jules CLI npm paketinin kurulumu başarısız oldu."
+    ["prefix_notice"]="Kurulum prefix'i: %s"
+    ["version_info"]="Jules CLI sürümü: %s"
+    ["interactive_intro"]="Şimdi Jules CLI'ya giriş yapmanız gerekiyor."
+    ["interactive_command"]="Lütfen 'jules login' komutunu çalıştırıp oturumu tamamlayın."
+    ["interactive_wait"]="Kimlik doğrulama tamamlanınca Enter'a basın."
+    ["manual_skip"]="'Tümünü Kur' modunda kimlik doğrulama atlandı."
+    ["manual_reminder"]="Lütfen daha sonra '${GREEN}jules login${NC}' komutunu manuel olarak çalıştırın."
+    ["manual_hint"]="Manuel oturum açma gerekebilir."
+    ["install_done"]="Jules CLI kurulumu tamamlandı!"
+    ["auth_prompt"]="Devam etmek için Enter'a basın..."
+)
+
+jules_text() {
+    local key="$1"
+    local default_value="${JULES_TEXT_EN[$key]:-$key}"
+    if [ "${LANGUAGE:-en}" = "tr" ]; then
+        printf "%s" "${JULES_TEXT_TR[$key]:-$default_value}"
+    else
+        printf "%s" "$default_value"
+    fi
+}
+
+# Jules CLI kurulumu
+install_jules_cli() {
+    local interactive_mode=${1:-true}
+    echo -e "\n${BLUE}╔═══════════════════════════════════════════════╗${NC}"
+    echo -e "${YELLOW}${INFO_TAG}${NC} $(jules_text install_title)"
+    echo -e "${BLUE}╚═══════════════════════════════════════════════╝${NC}"
+    
+    require_node_version 18 "Jules CLI" || return 1
+
+    if ! command -v npm >/dev/null 2>&1; then
+        echo -e "${RED}${ERROR_TAG}${NC} $(jules_text npm_missing)"
+        return 1
+    fi
+
+    if ! npm_install_global_with_fallback "@google/jules" "Jules CLI"; then
+        echo -e "${RED}${ERROR_TAG}${NC} $(jules_text install_fail)"
+        return 1
+    fi
+
+    if [ -n "${NPM_LAST_INSTALL_PREFIX}" ]; then
+        local jules_prefix_fmt
+        jules_prefix_fmt="$(jules_text prefix_notice)"
+        # shellcheck disable=SC2059
+        printf -v jules_prefix_msg "%s" "${NPM_LAST_INSTALL_PREFIX}"
+        echo -e "${YELLOW}${INFO_TAG}${NC} ${jules_prefix_msg}"
+    fi
+
+    local jules_version_fmt
+    jules_version_fmt="$(jules_text version_info)"
+    # shellcheck disable=SC2059
+    printf -v jules_version_msg "%s" "$(jules --version)"
+    echo -e "${GREEN}${SUCCESS_TAG}${NC} ${jules_version_msg}"
+    
+    if [ "$interactive_mode" = true ]; then
+        echo -e "\n${YELLOW}${INFO_TAG}${NC} $(jules_text interactive_intro)"
+        echo -e "${YELLOW}${INFO_TAG}${NC} $(jules_text interactive_command)"
+        echo -e "${YELLOW}${INFO_TAG}${NC} $(jules_text interactive_wait)\n"
+        
+        jules login </dev/tty >/dev/tty 2>&1 || echo -e "${YELLOW}${INFO_TAG}${NC} $(jules_text manual_hint)"
+        
+        echo -e "\n${YELLOW}${INFO_TAG}${NC} $(jules_text auth_prompt)"
+        read -r -p "" </dev/tty
+    else
+        echo -e "\n${YELLOW}${INFO_TAG}${NC} $(jules_text manual_skip)"
+        echo -e "${YELLOW}${INFO_TAG}${NC} $(jules_text manual_reminder)"
+    fi
+
+    echo -e "${GREEN}${SUCCESS_TAG}${NC} $(jules_text install_done)"
+}
+
+# Ana kurulum akışı
+main() {
+    install_jules_cli "$@"
+}
+
+main "$@"

--- a/modules/install_oh_my_zsh.sh
+++ b/modules/install_oh_my_zsh.sh
@@ -1,0 +1,131 @@
+#!/bin/bash
+set -euo pipefail
+
+UTILS_PATH="./modules/utils.sh"
+if [ ! -f "$UTILS_PATH" ] && [ -n "${BASH_SOURCE[0]:-}" ]; then
+    UTILS_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/utils.sh"
+fi
+# shellcheck source=/dev/null
+[ -f "$UTILS_PATH" ] && source "$UTILS_PATH"
+
+: "${RED:=$'\033[0;31m'}"
+: "${GREEN:=$'\033[0;32m'}"
+: "${YELLOW:=$'\033[1;33m'}"
+: "${BLUE:=$'\033[0;34m'}"
+: "${CYAN:=$'\033[0;36m'}"
+: "${NC:=$'\033[0m'}"
+
+declare -A OHMYZSH_TEXT_EN=(
+    ["install_title"]="Starting Oh My Zsh installation..."
+    ["zsh_missing"]="Zsh is not installed. Please install Zsh first."
+    ["already_installed"]="Oh My Zsh is already installed."
+    ["install_fail"]="Oh My Zsh installation failed."
+    ["install_success"]="Oh My Zsh installed successfully!"
+    ["backup_info"]="Existing .zshrc backed up to .zshrc.backup"
+    ["config_info"]="Oh My Zsh configuration files are in ~/.oh-my-zsh"
+    ["theme_info"]="You can change themes by editing ~/.zshrc"
+    ["install_done"]="Oh My Zsh installation completed!"
+)
+
+declare -A OHMYZSH_TEXT_TR=(
+    ["install_title"]="Oh My Zsh kurulumu başlatılıyor..."
+    ["zsh_missing"]="Zsh kurulu değil. Lütfen önce Zsh kurun."
+    ["already_installed"]="Oh My Zsh zaten kurulu."
+    ["install_fail"]="Oh My Zsh kurulumu başarısız oldu."
+    ["install_success"]="Oh My Zsh başarıyla kuruldu!"
+    ["backup_info"]="Mevcut .zshrc dosyası .zshrc.backup olarak yedeklendi"
+    ["config_info"]="Oh My Zsh yapılandırma dosyaları ~/.oh-my-zsh içinde"
+    ["theme_info"]="Temaları değiştirmek için ~/.zshrc dosyasını düzenleyin"
+    ["install_done"]="Oh My Zsh kurulumu tamamlandı!"
+)
+
+ohmyzsh_text() {
+    local key="$1"
+    local default_value="${OHMYZSH_TEXT_EN[$key]:-$key}"
+    if [ "${LANGUAGE:-en}" = "tr" ]; then
+        printf "%s" "${OHMYZSH_TEXT_TR[$key]:-$default_value}"
+    else
+        printf "%s" "$default_value"
+    fi
+}
+
+install_oh_my_zsh() {
+    echo -e "\n${BLUE}╔═══════════════════════════════════════════════╗${NC}"
+    echo -e "${YELLOW}${INFO_TAG}${NC} $(ohmyzsh_text install_title)"
+    echo -e "${BLUE}╚═══════════════════════════════════════════════╝${NC}"
+    
+    # Check if zsh is installed
+    if ! command -v zsh >/dev/null 2>&1; then
+        echo -e "${RED}${ERROR_TAG}${NC} $(ohmyzsh_text zsh_missing)"
+        return 1
+    fi
+
+    # Check if oh-my-zsh is already installed
+    if [ -d "$HOME/.oh-my-zsh" ]; then
+        echo -e "${GREEN}${SUCCESS_TAG}${NC} $(ohmyzsh_text already_installed)"
+        echo -e "${YELLOW}${INFO_TAG}${NC} $(ohmyzsh_text config_info)"
+        echo -e "${YELLOW}${INFO_TAG}${NC} $(ohmyzsh_text theme_info)"
+        return 0
+    fi
+
+    # Backup existing .zshrc if it exists
+    if [ -f "$HOME/.zshrc" ]; then
+        cp "$HOME/.zshrc" "$HOME/.zshrc.backup"
+        echo -e "${YELLOW}${INFO_TAG}${NC} $(ohmyzsh_text backup_info)"
+    fi
+
+    # Install Oh My Zsh using the official installation script
+    echo -e "${YELLOW}${INFO_TAG}${NC} Downloading Oh My Zsh installation script..."
+    
+    local install_script_url="https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh"
+    local temp_script="/tmp/ohmyzsh_install.sh"
+    
+    # Download the installation script
+    if command -v curl >/dev/null 2>&1; then
+        if ! curl -fsSL "$install_script_url" -o "$temp_script"; then
+            echo -e "${RED}${ERROR_TAG}${NC} Failed to download Oh My Zsh installation script"
+            return 1
+        fi
+    elif command -v wget >/dev/null 2>&1; then
+        if ! wget -qO "$temp_script" "$install_script_url"; then
+            echo -e "${RED}${ERROR_TAG}${NC} Failed to download Oh My Zsh installation script"
+            return 1
+        fi
+    else
+        echo -e "${RED}${ERROR_TAG}${NC} Neither curl nor wget is available. Please install one of them."
+        return 1
+    fi
+
+    # Make the script executable
+    chmod +x "$temp_script"
+
+    # Run the installation script with unattended mode
+    echo -e "${YELLOW}${INFO_TAG}${NC} Installing Oh My Zsh..."
+    if RUNZSH=no sh "$temp_script" --unattended; then
+        echo -e "${GREEN}${SUCCESS_TAG}${NC} $(ohmyzsh_text install_success)"
+        echo -e "${YELLOW}${INFO_TAG}${NC} $(ohmyzsh_text config_info)"
+        echo -e "${YELLOW}${INFO_TAG}${NC} $(ohmyzsh_text theme_info)"
+        echo -e "${GREEN}${SUCCESS_TAG}${NC} $(ohmyzsh_text install_done)"
+    else
+        echo -e "${RED}${ERROR_TAG}${NC} $(ohmyzsh_text install_fail)"
+        rm -f "$temp_script"
+        return 1
+    fi
+
+    # Clean up
+    rm -f "$temp_script"
+
+    # Verify installation
+    if [ -d "$HOME/.oh-my-zsh" ] && [ -f "$HOME/.zshrc" ]; then
+        echo -e "${GREEN}${SUCCESS_TAG}${NC} Oh My Zsh installation verified successfully!"
+    else
+        echo -e "${RED}${ERROR_TAG}${NC} Oh My Zsh installation verification failed"
+        return 1
+    fi
+}
+
+main() {
+    install_oh_my_zsh "$@"
+}
+
+main "$@"

--- a/modules/install_terminal_tools_menu.sh
+++ b/modules/install_terminal_tools_menu.sh
@@ -1,0 +1,121 @@
+#!/bin/bash
+# Windows CRLF düzeltme kontrolü
+if [ -f "$0" ]; then
+    if file "$0" | grep -q "CRLF"; then
+        if command -v dos2unix &> /dev/null; then dos2unix "$0"; elif command -v sed &> /dev/null; then sed -i 's/\r$//' "$0"; fi
+        exec bash "$0" "$@"
+    fi
+fi
+set -euo pipefail
+
+# Ortak yardımcı fonksiyonları yükle
+# shellcheck source=/dev/null
+source "./modules/utils.sh"
+
+: "${RED:=\033[0;31m}"
+: "${GREEN:=\033[0;32m}"
+: "${YELLOW:=\033[1;33m}"
+: "${BLUE:=\033[0;34m}"
+: "${CYAN:=\033[0;36m}"
+: "${NC:=\033[0m}"
+
+declare -A TERMINAL_MENU_TEXT_EN=(
+    ["menu_title"]="Terminal Tools Menu"
+    ["option1"]="Zsh (Advanced Shell)"
+    ["option2"]="Oh My Zsh (Zsh Framework)"
+    ["optionA"]="Install All Terminal Tools"
+    ["option_return"]="Return to Main Menu"
+    ["menu_hint"]="You can make multiple selections with commas (e.g., 1,2)."
+    ["prompt_choice"]="Your choice"
+    ["info_returning"]="Returning to the main menu..."
+    ["warning_invalid_choice"]="Invalid choice"
+    ["prompt_continue"]="Install another terminal tool? (y/n) [n]: "
+)
+
+declare -A TERMINAL_MENU_TEXT_TR=(
+    ["menu_title"]="Terminal Araçları Menüsü"
+    ["option1"]="Zsh (Gelişmiş Shell)"
+    ["option2"]="Oh My Zsh (Zsh Framework'ü)"
+    ["optionA"]="Tüm Terminal Araçlarını Kur"
+    ["option_return"]="Ana Menüye Dön"
+    ["menu_hint"]="Birden fazla seçim için virgül kullanabilirsiniz (örn: 1,2)."
+    ["prompt_choice"]="Seçiminiz"
+    ["info_returning"]="Ana menüye dönülüyor..."
+    ["warning_invalid_choice"]="Geçersiz seçim"
+    ["prompt_continue"]="Başka bir terminal aracı kurmak ister misiniz? (e/h) [h]: "
+)
+
+terminal_menu_text() {
+    local key="$1"
+    local default_value="${TERMINAL_MENU_TEXT_EN[$key]:-$key}"
+    if [ "${LANGUAGE:-en}" = "tr" ]; then
+        printf "%s" "${TERMINAL_MENU_TEXT_TR[$key]:-$default_value}"
+    else
+        printf "%s" "$default_value"
+    fi
+}
+
+install_terminal_tools_menu() {
+    local install_all="${1:-""}"
+
+    while true; do
+        local choices=""
+        if [ -z "$install_all" ]; then
+            clear
+            echo -e "\n${BLUE}╔═══════════════════════════════════════════════╗${NC}"
+            printf "${BLUE}║%*s║${NC}\n" -43 " $(terminal_menu_text menu_title) "
+            echo -e "${BLUE}╚═══════════════════════════════════════════════╝${NC}\n"
+            echo -e "  ${GREEN}1${NC} - $(terminal_menu_text option1)"
+            echo -e "  ${GREEN}2${NC} - $(terminal_menu_text option2)"
+            echo -e "  ${GREEN}A${NC} - $(terminal_menu_text optionA)"
+            echo -e "  ${RED}0${NC} - $(terminal_menu_text option_return)"
+            echo -e "\n${YELLOW}$(terminal_menu_text menu_hint)${NC}"
+
+            read -r -p "${YELLOW}$(terminal_menu_text prompt_choice):${NC} " choices </dev/tty
+            if [ "$choices" = "0" ] || [ -z "$choices" ]; then
+                echo -e "${YELLOW}$(terminal_menu_text info_returning)${NC}"
+                break
+            fi
+        else
+            choices="A" # Install all
+        fi
+
+        local all_installed=false
+        IFS=',' read -ra SELECTED_ITEMS <<< "$choices"
+
+        for choice in "${SELECTED_ITEMS[@]}"; do
+            choice=$(echo "$choice" | tr -d '[:space:]')
+            case $choice in
+                1) run_module "install_zsh" ;;
+                2) run_module "install_oh_my_zsh" ;;
+                A|a) 
+                    run_module "install_zsh"
+                    run_module "install_oh_my_zsh"
+                    all_installed=true
+                    ;;
+                0) 
+                    echo -e "${YELLOW}$(terminal_menu_text info_returning)${NC}"
+                    return 0
+                    ;;
+                *) 
+                    echo -e "${RED}$(terminal_menu_text warning_invalid_choice): $choice${NC}"
+                    ;;
+            esac
+        done
+
+        if [ "$all_installed" = true ] || [ -n "$install_all" ]; then
+            break
+        fi
+
+        read -r -p "${YELLOW}$(terminal_menu_text prompt_continue)${NC} " continue_choice </dev/tty
+        if [[ ! "$continue_choice" =~ ^([eEyY])$ ]]; then
+            break
+        fi
+    done
+}
+
+main() {
+    install_terminal_tools_menu "$@"
+}
+
+main "$@"

--- a/modules/install_zsh.sh
+++ b/modules/install_zsh.sh
@@ -1,0 +1,149 @@
+#!/bin/bash
+set -euo pipefail
+
+UTILS_PATH="./modules/utils.sh"
+if [ ! -f "$UTILS_PATH" ] && [ -n "${BASH_SOURCE[0]:-}" ]; then
+    UTILS_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/utils.sh"
+fi
+# shellcheck source=/dev/null
+[ -f "$UTILS_PATH" ] && source "$UTILS_PATH"
+
+: "${RED:=$'\033[0;31m'}"
+: "${GREEN:=$'\033[0;32m'}"
+: "${YELLOW:=$'\033[1;33m'}"
+: "${BLUE:=$'\033[0;34m'}"
+: "${CYAN:=$'\033[0;36m'}"
+: "${NC:=$'\033[0m'}"
+
+declare -A ZSH_TEXT_EN=(
+    ["install_title"]="Starting Zsh installation..."
+    ["already_installed"]="Zsh is already installed."
+    ["install_fail"]="Zsh installation failed."
+    ["version_info"]="Zsh version: %s"
+    ["shell_change_info"]="To make Zsh your default shell, run: chsh -s $(which zsh)"
+    ["install_done"]="Zsh installation completed!"
+)
+
+declare -A ZSH_TEXT_TR=(
+    ["install_title"]="Zsh kurulumu başlatılıyor..."
+    ["already_installed"]="Zsh zaten kurulu."
+    ["install_fail"]="Zsh kurulumu başarısız oldu."
+    ["version_info"]="Zsh sürümü: %s"
+    ["shell_change_info"]="Zsh'i varsayılan shell yapmak için: chsh -s $(which zsh)"
+    ["install_done"]="Zsh kurulumu tamamlandı!"
+)
+
+zsh_text() {
+    local key="$1"
+    local default_value="${ZSH_TEXT_EN[$key]:-$key}"
+    if [ "${LANGUAGE:-en}" = "tr" ]; then
+        printf "%s" "${ZSH_TEXT_TR[$key]:-$default_value}"
+    else
+        printf "%s" "$default_value"
+    fi
+}
+
+install_zsh() {
+    echo -e "\n${BLUE}╔═══════════════════════════════════════════════╗${NC}"
+    echo -e "${YELLOW}${INFO_TAG}${NC} $(zsh_text install_title)"
+    echo -e "${BLUE}╚═══════════════════════════════════════════════╝${NC}"
+    
+    # Check if zsh is already installed
+    if command -v zsh >/dev/null 2>&1; then
+        local zsh_version
+        zsh_version=$(zsh --version 2>/dev/null | head -n1 || echo "unknown")
+        echo -e "${GREEN}${SUCCESS_TAG}${NC} $(zsh_text already_installed)"
+        local version_fmt
+        version_fmt="$(zsh_text version_info)"
+        printf -v version_msg "%s" "$zsh_version"
+        echo -e "${GREEN}${INFO_TAG}${NC} ${version_msg}"
+        echo -e "${YELLOW}${INFO_TAG}${NC} $(zsh_text shell_change_info)"
+        return 0
+    fi
+
+    # Detect package manager and install zsh
+    local package_manager=""
+    if command -v apt-get >/dev/null 2>&1; then
+        package_manager="apt"
+    elif command -v yum >/dev/null 2>&1; then
+        package_manager="yum"
+    elif command -v dnf >/dev/null 2>&1; then
+        package_manager="dnf"
+    elif command -v pacman >/dev/null 2>&1; then
+        package_manager="pacman"
+    elif command -v zypper >/dev/null 2>&1; then
+        package_manager="zypper"
+    elif command -v brew >/dev/null 2>&1; then
+        package_manager="brew"
+    else
+        echo -e "${RED}${ERROR_TAG}${NC} No supported package manager found. Please install Zsh manually."
+        return 1
+    fi
+
+    echo -e "${YELLOW}${INFO_TAG}${NC} Installing Zsh using $package_manager..."
+    
+    # Check if we can use sudo
+    if ! sudo -n true 2>/dev/null; then
+        echo -e "${YELLOW}${INFO_TAG}${NC} Sudo access required. Please enter your password when prompted."
+    fi
+    
+    case $package_manager in
+        apt)
+            if ! { sudo apt-get update && sudo apt-get install -y zsh; } 2>/dev/null; then
+                echo -e "${RED}${ERROR_TAG}${NC} $(zsh_text install_fail)"
+                return 1
+            fi
+            ;;
+        yum)
+            if ! sudo yum install -y zsh 2>/dev/null; then
+                echo -e "${RED}${ERROR_TAG}${NC} $(zsh_text install_fail)"
+                return 1
+            fi
+            ;;
+        dnf)
+            if ! sudo dnf install -y zsh 2>/dev/null; then
+                echo -e "${RED}${ERROR_TAG}${NC} $(zsh_text install_fail)"
+                return 1
+            fi
+            ;;
+        pacman)
+            if ! sudo pacman -S --noconfirm zsh 2>/dev/null; then
+                echo -e "${RED}${ERROR_TAG}${NC} $(zsh_text install_fail)"
+                return 1
+            fi
+            ;;
+        zypper)
+            if ! sudo zypper install -y zsh 2>/dev/null; then
+                echo -e "${RED}${ERROR_TAG}${NC} $(zsh_text install_fail)"
+                return 1
+            fi
+            ;;
+        brew)
+            if ! brew install zsh 2>/dev/null; then
+                echo -e "${RED}${ERROR_TAG}${NC} $(zsh_text install_fail)"
+                return 1
+            fi
+            ;;
+    esac
+
+    # Verify installation
+    if command -v zsh >/dev/null 2>&1; then
+        local zsh_version
+        zsh_version=$(zsh --version 2>/dev/null | head -n1 || echo "unknown")
+        local version_fmt
+        version_fmt="$(zsh_text version_info)"
+        printf -v version_msg "%s" "$zsh_version"
+        echo -e "${GREEN}${SUCCESS_TAG}${NC} ${version_msg}"
+        echo -e "${YELLOW}${INFO_TAG}${NC} $(zsh_text shell_change_info)"
+        echo -e "${GREEN}${SUCCESS_TAG}${NC} $(zsh_text install_done)"
+    else
+        echo -e "${RED}${ERROR_TAG}${NC} $(zsh_text install_fail)"
+        return 1
+    fi
+}
+
+main() {
+    install_zsh "$@"
+}
+
+main "$@"

--- a/setup
+++ b/setup
@@ -52,6 +52,7 @@ declare -A SETUP_TEXT_EN=(
     ["menu_option10"]="Install GitHub CLI"
     ["menu_option11"]="Remove AI Frameworks"
     ["menu_option12"]="Manage MCP Servers"
+    ["menu_option13"]="Install Terminal Tools (Zsh, Oh My Zsh)"
     ["menu_optionA"]="Install Everything (Recommended)"
     ["menu_option0"]="Exit"
     ["menu_multi_hint"]="You can make multiple selections with commas (e.g., 1,2,5)."
@@ -89,6 +90,7 @@ declare -A SETUP_TEXT_TR=(
     ["menu_option10"]="GitHub CLI Kur"
     ["menu_option11"]="AI Framework'lerini Kaldır"
     ["menu_option12"]="MCP Sunucularını Yönet"
+    ["menu_option13"]="Terminal Araçlarını Kur (Zsh, Oh My Zsh)"
     ["menu_optionA"]="Tümünü Kur (Önerilen)"
     ["menu_option0"]="Çıkış"
     ["menu_multi_hint"]="Birden fazla seçim için virgül kullanabilirsiniz (örn: 1,2,5)."
@@ -273,6 +275,7 @@ main_menu() {
             echo -e "  ${GREEN}10${NC} - $(setup_text menu_option10)"
             echo -e "  ${GREEN}11${NC} - $(setup_text menu_option11)"
             echo -e "  ${GREEN}12${NC} - $(setup_text menu_option12)"
+            echo -e "  ${GREEN}13${NC} - $(setup_text menu_option13)"
             echo -e "  ${GREEN}A${NC} - $(setup_text menu_optionA)"
             echo -e "  ${GREEN}L${NC} - $(setup_text menu_language_option) ($(get_language_label "$LANGUAGE"))"
             echo -e "  ${RED}0${NC} - $(setup_text menu_option0)"
@@ -374,6 +377,7 @@ main_menu() {
                         run_module "manage_mcp_servers_menu"
                     fi
                     ;;
+                13) run_module "install_terminal_tools_menu" ;;
                 L)
                     language_menu
                     ;; 
@@ -387,6 +391,7 @@ main_menu() {
                         run_module "configure_glm_claude"
                         run_module "install_aux_tools_menu" "all"
                         run_module "install_github_cli"
+                        run_module "install_terminal_tools_menu" "all"
                         echo -e "\n${YELLOW}$(setup_text prompt_install_php)${NC}"
                         read -r install_php_choice </dev/tty
                         if [[ "$install_php_choice" =~ ^[EeYy]$ ]]; then
@@ -402,6 +407,7 @@ main_menu() {
                         run_module "configure_git"
                         run_module "configure_glm_claude"
                         run_module "install_github_cli"
+                        run_module "install_terminal_tools_menu" "all"
                         echo -e "\n${YELLOW}$(setup_text prompt_install_php)${NC}"
                         read -r install_php_choice </dev/tty
                         if [[ "$install_php_choice" =~ ^[EeYy]$ ]]; then


### PR DESCRIPTION
- Add Jules CLI as option 14 in AI CLI tools menu
- Fix Jules CLI installation script syntax errors
- Add new Terminal Tools menu with Zsh and Oh My Zsh options
- Create Zsh installation module supporting apt, yum, dnf, pacman, zypper, brew
- Create Oh My Zsh installation module with automatic .zshrc backup
- Update main setup script to include terminal tools menu as option 13
- Add terminal tools to 'Install All' workflow for both Linux and macOS
- Maintain bilingual support (Turkish/English) throughout