### PR TITLE
fix: Fix module download write errors and improve error handling

### DIFF
--- a/setup
+++ b/setup
@@ -159,6 +159,7 @@ download_file() {
     local output="$2"
     local max_attempts=3
     local attempt=1
+    local temp_output="/tmp/download_$$_${output##*/}"
 
     # Debug output
     echo "${INFO_TAG} Attempting to download: $(basename "$url")"
@@ -166,9 +167,15 @@ download_file() {
     while [ $attempt -le $max_attempts ]; do
         # Try curl first with enhanced parameters
         if curl -fsSL --connect-timeout 10 --max-time 60 --retry 2 --retry-delay 1 \
-           --user-agent "linux-ai-setup-script" "$url" -o "$output" 2>/tmp/curl_error.log 2>&1; then
-            echo "${SUCCESS_TAG} Download successful on attempt $attempt"
-            return 0
+           --user-agent "linux-ai-setup-script" "$url" -o "$temp_output" 2>/tmp/curl_error.log; then
+            # Move the file to the final destination
+            if mv "$temp_output" "$output" 2>/dev/null; then
+                echo "${SUCCESS_TAG} Download successful on attempt $attempt"
+                return 0
+            else
+                echo "${WARN_TAG} Failed to move downloaded file to destination"
+                rm -f "$temp_output"
+            fi
         fi
 
         # Show curl error if available
@@ -181,9 +188,15 @@ download_file() {
         if command -v wget &> /dev/null; then
             echo "${INFO_TAG} Trying with wget..."
             if wget --timeout=10 --tries=2 --user-agent="linux-ai-setup-script" \
-                    -qO "$output" "$url" 2>/tmp/wget_error.log 2>&1; then
-                echo "${SUCCESS_TAG} Download successful with wget on attempt $attempt"
-                return 0
+                    -qO "$temp_output" "$url" 2>/tmp/wget_error.log; then
+                # Move the file to the final destination
+                if mv "$temp_output" "$output" 2>/dev/null; then
+                    echo "${SUCCESS_TAG} Download successful with wget on attempt $attempt"
+                    return 0
+                else
+                    echo "${WARN_TAG} Failed to move downloaded file to destination"
+                    rm -f "$temp_output"
+                fi
             fi
             # Show wget error if available
             if [ -f /tmp/wget_error.log ] && [ -s /tmp/wget_error.log ]; then
@@ -193,7 +206,7 @@ download_file() {
         fi
 
         # Clean up partial file if it exists
-        [ -f "$output" ] && rm -f "$output"
+        [ -f "$temp_output" ] && rm -f "$temp_output"
 
         if [ $attempt -lt $max_attempts ]; then
             echo "${YELLOW}${WARN_TAG}${NC} Download attempt $attempt/$max_attempts failed, retrying in 2 seconds..."
@@ -257,7 +270,7 @@ prepare_remote_module_dir() {
     if [ -n "${REMOTE_MODULE_DIR:-}" ]; then
         return 0
     fi
-    REMOTE_MODULE_DIR="$HOME/.linux-ai-setup-script/remote_modules_$$"
+    REMOTE_MODULE_DIR="/tmp/linux-ai-setup-script-remote_modules_$$"
     mkdir -p "$REMOTE_MODULE_DIR/modules/utils"
 
     # Download critical modules using the inline download_file function
@@ -305,19 +318,12 @@ run_module() {
         fi
         local remote_file="${REMOTE_MODULE_DIR}/${module_name}.bash"
         if [ ! -f "$remote_file" ]; then
-            # Check if download_with_fallback is available (from utils.bash)
-            if declare -f download_with_fallback > /dev/null 2>&1; then
-                if ! download_with_fallback "$module_url" "$remote_file"; then
-                    echo -e "${RED}${ERROR_TAG}${NC} Failed to download module '$module_name'."
-                    return 1
-                fi
-            else
-                # Fallback to inline download_file function
-                if ! download_file "$module_url" "$remote_file"; then
-                    echo -e "${RED}${ERROR_TAG}${NC} Failed to download module '$module_name'."
-                    echo -e "${ERROR_TAG} Attempted URL: $module_url"
-                    return 1
-                fi
+            # Use the inline download_file function for better error reporting
+            echo -e "${INFO_TAG} Attempting to download: $(basename "$module_url")"
+            if ! download_file "$module_url" "$remote_file"; then
+                echo -e "${RED}${ERROR_TAG}${NC} Failed to download module '$module_name'."
+                echo -e "${ERROR_TAG} Attempted URL: $module_url"
+                return 1
             fi
         fi
         if ! (cd "$REMOTE_MODULE_DIR" && PKG_MANAGER="$PKG_MANAGER" UPDATE_CMD="$UPDATE_CMD" INSTALL_CMD="$INSTALL_CMD" LANGUAGE="$LANGUAGE" bash "$remote_file" "$@"); then
@@ -434,11 +440,13 @@ main_menu() {
                         run_module "setup/homebrew"
                     else
                         update_system
-                        if ! run_module "setup/wslu"; then
+                        # Try wslu module but make it optional
+                        if ! run_module "setup/wslu" 2>/dev/null; then
                             echo -e "${YELLOW}${WARN_TAG}${NC} Warning: wslu module failed to download. This is optional for browser integration."
                             echo -e "${CYAN}${INFO_TAG}${NC} Continuing with the rest of the installation..."
                         fi
-                        if ! run_module "setup/configure_windows_apps"; then
+                        # Try configure_windows_apps module but make it optional
+                        if ! run_module "setup/configure_windows_apps" 2>/dev/null; then
                             echo -e "${YELLOW}${WARN_TAG}${NC} Warning: Windows apps configuration module failed to download."
                             echo -e "${CYAN}${INFO_TAG}${NC} Continuing with the rest of the installation..."
                         fi
@@ -542,28 +550,30 @@ main_menu() {
                     else
                         # Option 1
                         update_system
-                        if ! run_module "setup/wslu"; then
+                        # Try wslu module but make it optional
+                        if ! run_module "setup/wslu" 2>/dev/null; then
                             echo -e "${YELLOW}${WARN_TAG}${NC} Warning: wslu module failed to download. This is optional for browser integration."
                             echo -e "${CYAN}${INFO_TAG}${NC} Continuing with the rest of the installation..."
                         fi
-                        if ! run_module "setup/configure_windows_apps"; then
+                        # Try configure_windows_apps module but make it optional
+                        if ! run_module "setup/configure_windows_apps" 2>/dev/null; then
                             echo -e "${YELLOW}${WARN_TAG}${NC} Warning: Windows apps configuration module failed to download."
                             echo -e "${CYAN}${INFO_TAG}${NC} Continuing with the rest of the installation..."
                         fi
                         clean_windows_paths_from_rc
-                        
+
                         # Option 2
                         run_module "menus/python_tools" "all"
-                        
+
                         # Option 3
                         run_module "menus/node" "all"
-                        
+
                         # Option 4
                         run_module "menus/ai_cli_tools" "all"
-                        
+
                         # Option 6
                         run_module "setup/configure_git"
-                        
+
                         # Option 10
                         run_module "setup/github_cli"
                     fi


### PR DESCRIPTION
Fixes curl "client returned ERROR on write" issues by:

1. Download files to /tmp first, then move to destination
2. Use /tmp for REMOTE_MODULE_DIR instead of HOME directory
3. Make wslu and configure_windows_apps modules truly optional
4. Simplify run_module to use inline download_file function

This resolves installation failures when optional modules cannot be downloaded due to file system permission issues.